### PR TITLE
Update db2.clj

### DIFF
--- a/src/metabase/driver/db2.clj
+++ b/src/metabase/driver/db2.clj
@@ -183,7 +183,7 @@
           :subprotocol "as400"
           :subname (str "//" host ":" port "/" dbname)}                    ;; :subname (str "//" host "/" dbname)}   (str "//" host ":" port "/" (or dbname db))}
          (dissoc details :host :port :dbname))
-  (sql-jdbc.common/handle-additional-options details, :seperator-style :semicolon)))
+  (sql-jdbc.common/handle-additional-options details, :separator-style :semicolon)))
 
 (defmethod driver/can-connect? :db2 [driver details]
   (let [connection (sql-jdbc.conn/connection-details->spec driver (ssh/include-ssh-tunnel! details))]


### PR DESCRIPTION
Hi @damienchambe 
Thank you for your splendid work on keeping this up to date with the new metabase versions! I've tested this on V7R1, works fine. Timestamps can now be displayed and filtered, which is wonderful. 

This is just a small fix to make it work on my machine:
-> Small spelling change of property name "separator-style" for the advanced options use.